### PR TITLE
docs(README): add local contributing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ Content changes should ideally first be raised as issues where they can be discu
    pnpm start
    ```
 
-
 ## License
 
 [MIT](LICENSE)


### PR DESCRIPTION
It wasn't apparent to me how to run the course locally. Adding instructions will help future contributors.

Additionally the `package.json` lockfile should be commited to ensure consistent dependencies.