### PR TITLE
fix(lessons/2): npx command in scripts explanation

### DIFF
--- a/2.md
+++ b/2.md
@@ -79,7 +79,7 @@ Pretty cool, right?
 
 Running `npx eleventy --serve` in the terminal is easy enough, but it would be even easier to just run `npm start` instead. To do this, we use [npm scripts](https://docs.npmjs.com/misc/scripts).
 
-In our `package.json` file, we already added a line containing `"start": "npx eleventy --serve"`. Instead of writing out the command `npx eleventy --serve` in our terminal to run Eleventy each time, we can use this npm script to run `npm start` with the same effect.
+In our `package.json` file, we already added a line containing `"start": "eleventy --serve"`. Instead of writing out the command `npx eleventy --serve` in our terminal to run Eleventy each time, we can use this npm script to run `npm start` with the same effect.
 
 > [!TIP]
 > The `start` script is a special one. It’s a default script that npm will run if you just run `npm start` in the terminal. There are a few others, such as `restart`, `stop` and `test`. You can read more about them [in the npm docs](https://docs.npmjs.com/misc/scripts).


### PR DESCRIPTION
The section "Setting up our scripts" references the contents of the `packages.json` mentioned earlier (in the section "Adding some dependencies").

However, the contents of `npm start` on the `packages.json` file does not include the `npx` command, instead it calls the `eleventy` command directly.